### PR TITLE
Favorite Route (DELETE)

### DIFF
--- a/stockTrainerApp/urls.py
+++ b/stockTrainerApp/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     path('stock/', csrf_exempt(views.stock), name='stock'),
     path('api/testdata/', views.TestListCreate.as_view()),
     path('charge/', csrf_exempt(views.charge), name='charge'),  # for now, we're disabling csrf requirements for charging
-    path('add_favorite/', csrf_exempt(views.add_favorite), name='add_favorite')
+    path('favorite/', csrf_exempt(views.favorite), name='favorite')
 ]
  
  #################################

--- a/stockTrainerBackEnd/Readme.md
+++ b/stockTrainerBackEnd/Readme.md
@@ -148,7 +148,7 @@ Example:
 }
 ```
 
-`/add_favorite/`
+`/favorite/`
 
 *POST*
 
@@ -179,6 +179,36 @@ Example:
     ]
 }
 ```
+
+*DELETE*
+
+##### Authentication
+
+The accessToken from the frontend should be attached as an authentication token. This
+will allow for our server to correctly identify the user, and delete the favorite from the
+user's favorite list. Make sure to attach the token to the header before making the request.
+
+##### Parameters
+
+The server is expecting a JSON body with a key of symbol. It should look like this:
+
+```
+{
+  "symbol": "AMZN"
+}
+```
+
+##### Return Format
+Data will be returned with a status code 200, in a json format.
+Example:
+```
+{
+    "favorites": [
+        "AAPL"
+    ]
+}
+```
+
 
 ### Code Style
 


### PR DESCRIPTION
# Description

Any front-end calls using the `add_favorite` endpoint will have to be modified to `favorite`.

Previously, the route to add favorites was not following RESTful conventions and was `/add_favorite/`. This pull request modifies the endpoint to `/favorite/` and introduces a DELETE method, so that favorites can be deleted from users. 

Currently, there is no error checking to see if the stock never actually existed in the user's favorites list, but that shouldn't really be a problem if users are following the flow of adding favorites before removing them. However, better error handling will be introduced in the future. The current implementation does not end up actually breaking or resulting in errors if the user does not have the stock in their favorites list.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Has been tested locally via Postman.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
